### PR TITLE
Add blackjack dealer bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # Codex-Testing
-Using this repository to learn how to use and test the fuctions of Codex, powered by Open AI. 
+
+Using this repository to learn how to use and test the functions of Codex, powered by Open AI.
+
+## Blackjack Dealer Bot
+
+Run the blackjack script to play against an automated dealer:
+
+```bash
+python blackjack.py
+```
+
+Follow the on-screen prompts to hit or stand and see if you can beat the dealer.

--- a/blackjack.py
+++ b/blackjack.py
@@ -1,0 +1,116 @@
+import random
+from dataclasses import dataclass, field
+
+CARD_VALUES = {
+    "2": 2,
+    "3": 3,
+    "4": 4,
+    "5": 5,
+    "6": 6,
+    "7": 7,
+    "8": 8,
+    "9": 9,
+    "10": 10,
+    "J": 10,
+    "Q": 10,
+    "K": 10,
+    "A": 11,
+}
+
+SUITS = ["Hearts", "Diamonds", "Clubs", "Spades"]
+RANKS = ["2", "3", "4", "5", "6", "7", "8", "9", "10", "J", "Q", "K", "A"]
+
+
+@dataclass
+class Deck:
+    """Represent a shuffled deck of 52 playing cards."""
+
+    cards: list[tuple[str, str]] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        self.cards = [(rank, suit) for suit in SUITS for rank in RANKS]
+        random.shuffle(self.cards)
+
+    def draw(self) -> tuple[str, str]:
+        """Remove and return the top card from the deck."""
+        return self.cards.pop()
+
+
+def calculate_hand_value(hand: list[tuple[str, str]]) -> int:
+    """Return the best score for the given hand in blackjack."""
+    value = sum(CARD_VALUES[rank] for rank, _ in hand)
+    aces = sum(1 for rank, _ in hand if rank == "A")
+    while value > 21 and aces:
+        value -= 10
+        aces -= 1
+    return value
+
+
+class BlackjackGame:
+    """Play a simple game of blackjack against an automated dealer."""
+
+    def __init__(self) -> None:
+        self.deck = Deck()
+        self.player_hand: list[tuple[str, str]] = []
+        self.dealer_hand: list[tuple[str, str]] = []
+
+    def deal_initial(self) -> None:
+        for _ in range(2):
+            self.player_hand.append(self.deck.draw())
+            self.dealer_hand.append(self.deck.draw())
+
+    def hit(self, hand: list[tuple[str, str]]) -> None:
+        hand.append(self.deck.draw())
+
+    @staticmethod
+    def format_hand(hand: list[tuple[str, str]]) -> str:
+        return ", ".join(f"{rank} of {suit}" for rank, suit in hand)
+
+    def play(self) -> None:
+        self.deal_initial()
+        while True:
+            print(f"Dealer shows: {self.dealer_hand[0][0]} of {self.dealer_hand[0][1]}")
+            player_value = calculate_hand_value(self.player_hand)
+            print(
+                f"Your hand: {self.format_hand(self.player_hand)} (value {player_value})"
+            )
+            if player_value == 21:
+                print("Blackjack! You win!")
+                return
+            choice = input("Hit or stand? [h/s]: ").strip().lower()
+            if choice.startswith("h"):
+                self.hit(self.player_hand)
+                player_value = calculate_hand_value(self.player_hand)
+                if player_value > 21:
+                    print(
+                        f"You bust with {self.format_hand(self.player_hand)} (value {player_value})."
+                    )
+                    return
+            else:
+                break
+
+        print(
+            f"Dealer's hand: {self.format_hand(self.dealer_hand)} (value {calculate_hand_value(self.dealer_hand)})"
+        )
+        while calculate_hand_value(self.dealer_hand) < 17:
+            self.hit(self.dealer_hand)
+            print(
+                f"Dealer hits: {self.format_hand(self.dealer_hand)} (value {calculate_hand_value(self.dealer_hand)})"
+            )
+            if calculate_hand_value(self.dealer_hand) > 21:
+                print("Dealer busts! You win.")
+                return
+
+        player_value = calculate_hand_value(self.player_hand)
+        dealer_value = calculate_hand_value(self.dealer_hand)
+        print(f"Final hands - You: {player_value}, Dealer: {dealer_value}")
+        if dealer_value > player_value:
+            print("Dealer wins.")
+        elif dealer_value < player_value:
+            print("You win!")
+        else:
+            print("Push (tie).")
+
+
+if __name__ == "__main__":
+    BlackjackGame().play()

--- a/tests/test_blackjack.py
+++ b/tests/test_blackjack.py
@@ -1,0 +1,27 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import blackjack
+
+
+def test_deck_has_52_unique_cards():
+    deck = blackjack.Deck()
+    assert len(deck.cards) == 52
+    assert len(set(deck.cards)) == 52
+
+
+def test_calculate_hand_value_with_aces():
+    hand = [("A", "Spades"), ("9", "Hearts")]
+    assert blackjack.calculate_hand_value(hand) == 20
+    hand = [("A", "Spades"), ("9", "Hearts"), ("A", "Diamonds")]
+    assert blackjack.calculate_hand_value(hand) == 21
+
+
+def test_deal_initial():
+    game = blackjack.BlackjackGame()
+    game.deal_initial()
+    assert len(game.player_hand) == 2
+    assert len(game.dealer_hand) == 2
+    assert len(game.deck.cards) == 52 - 4


### PR DESCRIPTION
## Summary
- add a blackjack dealer script with deck, hand values and interactive play loop
- document how to run the blackjack game
- test deck size, ace handling and initial deal logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b130438bf8832195593bbfc63173fb